### PR TITLE
Fix contract address text overflow on iphones

### DIFF
--- a/packages/zorb-web-site/src/Frame.tsx
+++ b/packages/zorb-web-site/src/Frame.tsx
@@ -135,6 +135,9 @@ export const Frame = ({ tokens }: any) => {
                   text-decoration: none;
                   color: white;
                   white-space: pre;
+                  @media only screen and (min-width: 400px) {
+                    font-size: 10px;
+                  }
                 `}
                 href={`http://etherscan.io/address/${ZORB_CONTRACT}`}
               >


### PR DESCRIPTION
Fix contract address text overflow on iphones
<img width="488" alt="Screen Shot 2022-01-01 at 17 26 33" src="https://user-images.githubusercontent.com/2352181/147852789-417a0a36-fe2f-4267-81e3-8809cbf3489b.png">
