### PR TITLE
safari size fix

### DIFF
--- a/packages/zorb-web-component/src/Zorb.svelte
+++ b/packages/zorb-web-component/src/Zorb.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import { gradientForAddress } from "./lib";
   import {instanceCount} from './instanceCounter';
-  export let size = undefined;
+  export let size = '100%';
   export let address = "0x0000000000000000000000000000000000000000";
   
   const gradientInfo = gradientForAddress(address);


### PR DESCRIPTION
Apparently Zorbs without explicit `width` or `height` [are not rendered on Safari](https://stackoverflow.com/questions/61719982/svg-images-not-rendering-in-safari).

My suggest would be to add default size of 100%, WDYT @iainnash ?