### PR TITLE
correct media query

### DIFF
--- a/packages/zorb-web-site/src/Frame.tsx
+++ b/packages/zorb-web-site/src/Frame.tsx
@@ -135,7 +135,7 @@ export const Frame = ({ tokens }: any) => {
                   text-decoration: none;
                   color: white;
                   white-space: pre;
-                  @media only screen and (min-width: 400px) {
+                  @media only screen and (max-width: 400px) {
                     font-size: 10px;
                   }
                 `}


### PR DESCRIPTION
for contract address on iphones