### PR TITLE
fix: s/Ony/Only

### DIFF
--- a/packages/zorb-contracts/contracts/ZorbNFT.sol
+++ b/packages/zorb-contracts/contracts/ZorbNFT.sol
@@ -96,7 +96,7 @@ contract ZorbNFT is ERC721, Ownable {
 
     /// Checks if a contract interation is approved or by owner
     modifier onlyApproved(uint256 tokenId) {
-        require(_isApprovedOrOwner(msg.sender, tokenId), "Ony approved");
+        require(_isApprovedOrOwner(msg.sender, tokenId), "Only approved");
         _;
     }
 


### PR DESCRIPTION
## Summary

Closes https://github.com/ourzora/zorb/issues/18

This updates `Ony` to `Only` in `onlyApproved`'s `require` messaging. 