### PR TITLE
feat: add an option to download the Zorb

### DIFF
--- a/packages/zorb-web-site/pages/nft/[id].tsx
+++ b/packages/zorb-web-site/pages/nft/[id].tsx
@@ -109,6 +109,13 @@ export default function Zorb({ id, tokenInfo }: any) {
                 View on ZORA <ArrowNext />
               </a>
             </div>
+            <div>
+              <a
+                download={`zorb-${id}.svg`}
+                href={image}
+                title={`Zorb #${id}`}
+              >💾 Download SVG</a>
+            </div>
           </div>
         </RoundedContainer>
       </div>


### PR DESCRIPTION
## Summary

Closes #20 

This adds an option to download an individual Zorb below viewing it on Etherscan or Zora:

![download-zorb-preview](https://user-images.githubusercontent.com/78528185/147999727-eb17bff2-ff4f-44b3-a05f-038f1813c461.gif)

### Notes for reviewers 👓

- This uses [`HTMLAnchorElement.download`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/download), along with the `image` and `id` already available in context.
- I'm happy to receive any feedback with respect to the design or to follow any design system guidelines. Also, if you all prefer that I remove the floppy disk emoji 💾 or update the copy, I'm all ears.

### Deploy Previews via [`almndbtr/zora#1`](https://github.com/almndbtr/zorb/pull/1)

🔍 Inspect: [https://vercel.com/almndbtr/zorb/4hcuVSNeoWHT1kuHAxzs3dxMuNJt](https://vercel.com/almndbtr/zorb/4hcuVSNeoWHT1kuHAxzs3dxMuNJt)  
✅ Preview: [https://zorb-git-almndbtr-download-spike-almndbtr.vercel.app](https://zorb-git-almndbtr-download-spike-almndbtr.vercel.app)